### PR TITLE
maia-wasm: fix uncaught PATCH errors and gain change errors

### DIFF
--- a/maia-wasm/src/ui.rs
+++ b/maia-wasm/src/ui.rs
@@ -395,10 +395,4 @@ impl Ui {
         }
         Ok(())
     }
-
-    // fn update_server_preferences(&self, json: &maia_json::Api) -> Result<(), JsValue> {
-    //     let mut p = self.preferences.borrow_mut();
-    //     p.update_ad9361_rx_lo_frequency(json.ad9361.rx_lo_frequency)?;
-    //     p.update_ad9361_sampling_frequency(json.ad9361.
-    // }
 }

--- a/maia-wasm/src/ui/patch.rs
+++ b/maia-wasm/src/ui/patch.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use wasm_bindgen::JsValue;
-use web_sys::{Request, RequestInit};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{Request, RequestInit, Response};
 
 pub fn json_patch<T: Serialize>(url: &str, json: &T) -> Result<Request, JsValue> {
     let mut opts = RequestInit::new();
@@ -11,4 +12,38 @@ pub fn json_patch<T: Serialize>(url: &str, json: &T) -> Result<Request, JsValue>
     let request = Request::new_with_str_and_init(url, &opts)?;
     request.headers().set("Content-Type", "application/json")?;
     Ok(request)
+}
+
+pub async fn response_to_string(response: &Response) -> Result<String, JsValue> {
+    Ok(JsFuture::from(response.text()?)
+        .await?
+        .as_string()
+        .ok_or("unable to convert fetch text to string")?)
+}
+
+pub async fn response_to_json<T>(response: &Response) -> Result<T, JsValue>
+where
+    for<'a> T: serde::Deserialize<'a>,
+{
+    let json = serde_json::from_str(&response_to_string(response).await?)
+        .map_err(|_| format!("unable to parse {} JSON", std::any::type_name::<T>()))?;
+    Ok(json)
+}
+
+pub enum PatchError {
+    RequestFailed(String),
+    OtherError(JsValue),
+}
+
+impl From<JsValue> for PatchError {
+    fn from(value: JsValue) -> PatchError {
+        PatchError::OtherError(value)
+    }
+}
+
+pub fn ignore_request_failed<T>(x: Result<T, PatchError>) -> Result<(), JsValue> {
+    match x {
+        Err(PatchError::OtherError(err)) => Err(err),
+        _ => Ok(()),
+    }
 }


### PR DESCRIPTION
This addresses the problems spotted in #2, by the following changes:

* Instead of causing an uncaught error in a promise when a PATCH request fails with an error 500, we log the error to the console and terminate the promise normally.
* We do not attempt to change the RX gain unless the AGC mode is "manual".
