### PR TITLE
maia-wasm: let waterfall grow to occupy empty viewport space

### DIFF
--- a/maia-wasm/assets/index.html
+++ b/maia-wasm/assets/index.html
@@ -36,51 +36,53 @@
       </form>
     </dialog>
 
-    <canvas id="canvas"></canvas>
+    <div class="main_screen">
+      <canvas id="canvas"></canvas>
 
-    <form class="ui">
-      <label>Colormap
-        <select id="colormap_select">
-	  <option>Turbo</option>
-	  <option>Viridis</option>
-        </select>
-      </label>
-      <fieldset class="waterfall_levels">
-        <label for="waterfall_min">Waterfall min</label>/<label for="waterfall_max">max</label>
-        <input type="number" id="waterfall_min" value="35" step="1" min="0">
-        <input type="number" id="waterfall_max" value="85" step="1" min="0">
-      </fieldset>
-      <label>RX freq
-        <input type="number" class="rf_frequency" id="ad9361_rx_lo_frequency" step="0.001" min="70" max="6000">
-        MHz
-      </label>
-      <label>Sampling freq
-        <input type="number" class="baseband_frequency" id="ad9361_sampling_frequency" step="0.001" max="61.44">
-        Msps
-      </label>
-      <label>RX bandwidth
-        <input type="number" class="baseband_frequency" id="ad9361_rx_rf_bandwidth" step="0.001" max="56">
-        MHz
-      </label>
-      <label>RX gain
-        <input type="number" class="gain" id="ad9361_rx_gain" step="1" min="-10" max="73">
-        dB
-      </label>
-      <label>RX AGC
-        <select id="ad9361_rx_gain_mode">
-	  <option>Manual</option>
-	  <option>Fast attack</option>
-          <option>Slow attack</option>
-          <option>Hybrid</option>
-        </select>
-      </label>
-      <label>Spectrum rate
-        <input type="number" id="spectrometer_output_sampling_frequency" step="any" min="0">
-        Hz
-      </label>
-      <button type="button" id="recorder_button"></button>
-      <button type="button" id="recording_properties_button">Recording</button>
-    </form>
+      <form class="ui">
+        <label>Colormap
+          <select id="colormap_select">
+	    <option>Turbo</option>
+	    <option>Viridis</option>
+          </select>
+        </label>
+        <fieldset class="waterfall_levels">
+          <label for="waterfall_min">Waterfall min</label>/<label for="waterfall_max">max</label>
+          <input type="number" id="waterfall_min" value="35" step="1" min="0">
+          <input type="number" id="waterfall_max" value="85" step="1" min="0">
+        </fieldset>
+        <label>RX freq
+          <input type="number" class="rf_frequency" id="ad9361_rx_lo_frequency" step="0.001" min="70" max="6000">
+          MHz
+        </label>
+        <label>Sampling freq
+          <input type="number" class="baseband_frequency" id="ad9361_sampling_frequency" step="0.001" max="61.44">
+          Msps
+        </label>
+        <label>RX bandwidth
+          <input type="number" class="baseband_frequency" id="ad9361_rx_rf_bandwidth" step="0.001" max="56">
+          MHz
+        </label>
+        <label>RX gain
+          <input type="number" class="gain" id="ad9361_rx_gain" step="1" min="-10" max="73">
+          dB
+        </label>
+        <label>RX AGC
+          <select id="ad9361_rx_gain_mode">
+	    <option>Manual</option>
+	    <option>Fast attack</option>
+            <option>Slow attack</option>
+            <option>Hybrid</option>
+          </select>
+        </label>
+        <label>Spectrum rate
+          <input type="number" id="spectrometer_output_sampling_frequency" step="any" min="0">
+          Hz
+        </label>
+        <button type="button" id="recorder_button"></button>
+        <button type="button" id="recording_properties_button">Recording</button>
+      </form>
+    </div>
 
   </body>
 </html>

--- a/maia-wasm/assets/style.css
+++ b/maia-wasm/assets/style.css
@@ -59,10 +59,21 @@ body {
     -ms-user-select: none; /* IE 10+ */
 }
 
+/* The main screen is a flex formed by the waterfall canvas and the UI form. The
+waterfall grows as needed so that at least all the viewport is used
+vertically. The flex can be larger if the UI form needs to overflow past the end
+of the screen, since the waterfall has a minimum height of 75vh. */
+.main_screen {
+    display: flex;
+    flex-flow: column;
+    min-height: 100vh;
+}
+
 #canvas {
     touch-action: none;
     width: 100vw;
-    height: 80vh;
+    height: 0; /* all the canvas height comes from growing the flex */
+    flex: 1 0 75vh;
 }
 
 html {
@@ -156,14 +167,14 @@ input:invalid {
 }
 
 form.ui {
+    flex: 0; /* do not grow and steal space to the waterfall */
     display: flex;
     flex-flow: row wrap;
     align-items: center;
     justify-content: space-around;
     column-gap: 20px;
     row-gap: 10px;
-    padding-left: 10px;
-    padding-right: 10px;
+    padding: 10px;
 }
 
 .ui fieldset {


### PR DESCRIPTION
This removes the blank space that can appear below the UI form when the viewport is wide, by letting the waterfall grow to occupy the remaining space.

A flexbox containing the waterfall canvas and the UI form is added. This flexbox is used to control the waterfall size, which has a minimum of 75vh (this has been reduced from 80vh) but can grow to fill the remainig space of the flexbox minimum height, which is 100vh.

The UI form can cause the flexbox to overflow if the screen is narrow enough that the form doesn't fit in 25vh.

---

This is how the new layout looks like on my 1920x1080 PC screen (opening the image in a new tab is recommended, since with a white background it is difficult to tell where the screenshot ends).

![maia-fullscreen](https://user-images.githubusercontent.com/15093841/223843898-f5d603f7-4aed-4a8c-8587-5a99824ce8c8.jpg)

This is Firefox emulating a Galaxy S20+ Android 11 Chrome 87 in portrait and landscape.

![maia-s20p_portrait](https://user-images.githubusercontent.com/15093841/223844469-b3b463e6-14d1-4812-af65-87588f631232.jpg)

![maia-s20p_landscape](https://user-images.githubusercontent.com/15093841/223844481-0e1b2ddc-955b-4882-9350-148c2cc42e88.jpg)
