### PR TITLE
maia-wasm: fix clippy lints

### DIFF
--- a/maia-wasm/src/render/engine/texture.rs
+++ b/maia-wasm/src/render/engine/texture.rs
@@ -111,25 +111,20 @@ impl TextureParameter {
 /// Magnification filter.
 ///
 /// This enum lists the magnification filters supported by WebGL2.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
 #[repr(u32)]
 pub enum TextureMagFilter {
     /// Linear filtering.
+    #[default]
     Linear = WebGl2RenderingContext::LINEAR,
     /// Nearest-neighbor filtering.
     Nearest = WebGl2RenderingContext::NEAREST,
 }
 
-impl Default for TextureMagFilter {
-    fn default() -> TextureMagFilter {
-        TextureMagFilter::Linear
-    }
-}
-
 /// Minification filter.
 ///
 /// This enum lists the minification filters supported by WebGL2.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
 #[repr(u32)]
 pub enum TextureMinFilter {
     /// Linear filtering.
@@ -141,35 +136,25 @@ pub enum TextureMinFilter {
     /// Linear filtering using the nearest mipmap.
     LinearMipmapNearest = WebGl2RenderingContext::LINEAR_MIPMAP_NEAREST,
     /// Nearest-neighbor filtering using linear interpolation between mipmaps.
+    #[default]
     NearestMipmapLinear = WebGl2RenderingContext::NEAREST_MIPMAP_LINEAR,
     /// Linear filtering using linear interpolation between mipmaps.
     LinearMipmapLinear = WebGl2RenderingContext::LINEAR_MIPMAP_LINEAR,
 }
 
-impl Default for TextureMinFilter {
-    fn default() -> TextureMinFilter {
-        TextureMinFilter::NearestMipmapLinear
-    }
-}
-
 /// Texture wrapping.
 ///
 /// This enum lists the texture wrapping settings supported by WebGL2.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
 #[repr(u32)]
 pub enum TextureWrap {
     /// Repeat.
+    #[default]
     Repeat = WebGl2RenderingContext::REPEAT,
     /// Clamp to edge.
     ClampToEdge = WebGl2RenderingContext::CLAMP_TO_EDGE,
     /// Mirrored repeat.
     MirroredRepeat = WebGl2RenderingContext::MIRRORED_REPEAT,
-}
-
-impl Default for TextureWrap {
-    fn default() -> TextureWrap {
-        TextureWrap::Repeat
-    }
 }
 
 /// WebGL2 texture internal format.

--- a/maia-wasm/src/waterfall.rs
+++ b/maia-wasm/src/waterfall.rs
@@ -468,10 +468,7 @@ impl Waterfall {
 
         let start = ((self.center_freq - 0.5 * self.samp_rate) / step).floor() as i32 - 1;
         let stop = ((self.center_freq + 0.5 * self.samp_rate) / step).ceil() as i32 + 1;
-        let mut freqs = (start..=stop)
-            .into_iter()
-            .map(|k| k as f64 * step)
-            .collect::<Vec<_>>();
+        let mut freqs = (start..=stop).map(|k| k as f64 * step).collect::<Vec<_>>();
         let mut nfreqs = Vec::with_capacity(max_depth + 1);
         nfreqs.push(freqs.len());
         let mut freq_radixes = Vec::with_capacity(max_depth);
@@ -530,7 +527,7 @@ impl Waterfall {
             })
             .collect::<Vec<u16>>();
 
-        let indices_ticks = (0..freqs.len() as u16).into_iter().collect::<Vec<u16>>();
+        let indices_ticks = (0..freqs.len() as u16).collect::<Vec<u16>>();
 
         let texture_texts = freqs_labels
             .iter()


### PR DESCRIPTION
Fix clippy lints that have appeared in rust 1.68.