### PR TITLE
add CHANGELOGs and bump some versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to maia-sdr will be documented in this file. Each of the
+components of maia-sdr (maia-hdl, maia-httpd, maia-wasm) has its own more
+detailed changelog inside the component directory.
+
+maia-sdr is versioned in synchronization with all its components. A new version
+tag for maia-sdr bumps the version of each of the components that had
+changes. The versioning of each component evolves independently, according to
+whether there are no changes, only non-API-breaking changes, or API-breaking
+changes since the last version tag for maia-sdr. The semantic version of
+maia-sdr is bumped according to whether any components had API-breaking changes
+(this causes an API-breaking bump in the maia-sdr version number).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Bumped maia-httpd to v0.1.1. Only a minor security bugfix.
+- Bumped maia-wasm to v0.2.0. API breaking change because of a refactor to improve
+  reusability. Includes other minor changes.
+
+## [0.1.0] - 2023-02-10
+
+### Added
+
+- Initial release of maia-sdr: support for the ADALM Pluto including a web
+  interface with real-time waterfall display and IQ recording in SigMF format to
+  the Pluto RAM.

--- a/maia-hdl/CHANGELOG.md
+++ b/maia-hdl/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to maia-hdl will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2023-02-10
+
+### Added
+
+- Initial release of maia-hdl: includes an FFT implementation, a spectrometer,
+  an IQ recorder to RAM, and a Vivado project for the ADALM Pluto.

--- a/maia-httpd/CHANGELOG.md
+++ b/maia-httpd/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to maia-httpd will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Do not use chrono default features: this fixes a potential security bug by
+  avoiding a dependency on an old version of the time crate.
+
+## [0.1.0] - 2023-02-10
+
+### Added
+
+- Initial release of maia-httpd: supports a waterfall data server in a
+  WebSocket, a REST API to control the FPGA core and the AD9361 IIO device, and
+  download of IQ recordings in SigMF format.

--- a/maia-httpd/Cargo.toml
+++ b/maia-httpd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maia-httpd"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Daniel Estevez <daniel@destevez.net>"]
 description = "Maia SDR HTTP server"

--- a/maia-wasm/CHANGELOG.md
+++ b/maia-wasm/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to maia-wasm will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Standalone waterfall example.
+
+### Fixed
+
+- JS promise failure in the UI code when a PATCH request fails.
+- Avoid PATCHing RX gain in non-manual AGC mode.
+- Calculation of center coordinates in pointer interaction with waterfall.
+
+### Changed
+
+- Refactor to improve waterfall reusability.
+- Waterfall size: the waterfall will grow vertically to occupy the empty
+  viewport space.
+
+## [0.1.0] - 2023-02-10
+
+### Added
+
+- Initial release of maia-wasm: WebGL2 waterfall obtaining data from a
+  WebSocket and HTML form-based UI to interact with the REST API of
+  maia-httpd.

--- a/maia-wasm/Cargo.toml
+++ b/maia-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maia-wasm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Daniel Estevez <daniel@destevez.net>"]
 description = "Maia SDR WASM frontend"


### PR DESCRIPTION
Bump maia-httpd to v0.1.1 because of minor changes and maia-wasm to v0.2.0 because of API-breaking changes.