### PR TITLE
Recording enhancements

### DIFF
--- a/maia-httpd/maia-json/src/lib.rs
+++ b/maia-httpd/maia-json/src/lib.rs
@@ -195,6 +195,8 @@ pub struct Recorder {
     pub state: RecorderState,
     /// Recoder sampling mode.
     pub mode: RecorderMode,
+    /// Automatically prepend timestamp to file name.
+    pub prepend_timestamp: bool,
 }
 
 /// IQ recorder PATCH JSON schema.
@@ -209,6 +211,9 @@ pub struct PatchRecorder {
     /// Recorder sampling mode.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<RecorderMode>,
+    /// Automatically prepend timestamp to file name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prepend_timestamp: Option<bool>,
 }
 
 /// Command to change the IQ recorder state.

--- a/maia-httpd/maia-json/src/lib.rs
+++ b/maia-httpd/maia-json/src/lib.rs
@@ -189,7 +189,7 @@ pub struct PatchSpectrometer {
 ///
 /// This JSON schema corresponds to GET requests on `/api/recorder`. It contains
 /// the settings of the IQ recorder.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Recorder {
     /// Current recorder state.
     pub state: RecorderState,
@@ -197,13 +197,15 @@ pub struct Recorder {
     pub mode: RecorderMode,
     /// Automatically prepend timestamp to file name.
     pub prepend_timestamp: bool,
+    /// Maximum recording duration (in seconds).
+    pub maximum_duration: f64,
 }
 
 /// IQ recorder PATCH JSON schema.
 ///
 /// This JSON schema corresponds to PATCH requests on `/api/recorder`. It is
 /// used to modify the settings of the IQ recorder.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct PatchRecorder {
     /// Command to change the recorder state.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -214,6 +216,9 @@ pub struct PatchRecorder {
     /// Automatically prepend timestamp to file name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prepend_timestamp: Option<bool>,
+    /// Maximum recording duration (in seconds).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum_duration: Option<f64>,
 }
 
 /// Command to change the IQ recorder state.

--- a/maia-wasm/assets/index.html
+++ b/maia-wasm/assets/index.html
@@ -21,7 +21,11 @@
     <dialog class="ui" id="recording_dialog">
       <form method="dialog" id="recording_form">
         <label for="recording_metadata_file">Filename</label>
-        <input type="text" id="recording_metadata_filename">
+        <div class="recording_filename_properties">
+          <input type="text" id="recording_metadata_filename">
+          <label for="recorder_prepend_timestamp">Add date/time</label>
+          <input type="checkbox" id="recorder_prepend_timestamp">
+        </div>
         <label for="recording_metadata_description">Description</label>
         <input type="text" id="recording_metadata_description">
         <label for="recording_metadata_author">Author</label>

--- a/maia-wasm/assets/index.html
+++ b/maia-wasm/assets/index.html
@@ -35,6 +35,8 @@
           <option>8 bit IQ</option>
           <option>12 bit IQ</option>
         </select>
+        <label for="recorder_maximum_duration">Max duration (s)</label>
+        <input type="number" min="0" step="any" id="recorder_maximum_duration">
         <a id="download_recording" href="/recording" download>Download recording</a>
         <button id="close_recording_dialog" value="close" autofocus>Close</button>
       </form>

--- a/maia-wasm/assets/style.css
+++ b/maia-wasm/assets/style.css
@@ -238,8 +238,19 @@ input.gain {
 }
 
 #recording_form input,
-#recording_form select {
+#recording_form select,
+#recording_form .recording_filename_properties {
     grid-column: 2/5;
+}
+
+.recording_filename_properties {
+    display: flex;
+    align-items: center;
+    column-gap: 10px;
+}
+
+.recording_filename_properties input:first-child {
+    flex: 1;
 }
 
 #download_recording {

--- a/maia-wasm/src/ui.rs
+++ b/maia-wasm/src/ui.rs
@@ -73,6 +73,7 @@ ui_elements! {
     recording_metadata_description: HtmlInputElement => TextInput,
     recording_metadata_author: HtmlInputElement => TextInput,
     recorder_mode: HtmlSelectElement => EnumInput<maia_json::RecorderMode>,
+    recorder_maximum_duration: HtmlInputElement => NumberInput<f64>,
 }
 
 impl Ui {
@@ -116,7 +117,8 @@ impl Ui {
             recorder_prepend_timestamp,
             recording_metadata_description,
             recording_metadata_author,
-            recorder_mode
+            recorder_mode,
+            recorder_maximum_duration
         );
 
         // This uses a custom onchange function that calls the macro-generated one.
@@ -166,7 +168,8 @@ impl Ui {
         maia_json::PatchRecorder,
         RECORDER_URL,
         prepend_timestamp,
-        mode
+        mode,
+        maximum_duration
     );
 
     fn set_api_get_periodic(&self, interval_ms: i32) -> Result<(), JsValue> {

--- a/maia-wasm/src/ui.rs
+++ b/maia-wasm/src/ui.rs
@@ -18,7 +18,7 @@ use crate::render::RenderEngine;
 use crate::waterfall::Waterfall;
 
 use active::IsElementActive;
-use input::{EnumInput, InputElement, NumberInput, TextInput};
+use input::{CheckboxInput, EnumInput, InputElement, NumberInput, TextInput};
 use patch::{json_patch, PatchError};
 
 mod active;
@@ -69,6 +69,7 @@ ui_elements! {
     spectrometer_output_sampling_frequency: HtmlInputElement
         => NumberInput<f64, input::IntegerPresentation>,
     recording_metadata_filename: HtmlInputElement => TextInput,
+    recorder_prepend_timestamp: HtmlInputElement => CheckboxInput,
     recording_metadata_description: HtmlInputElement => TextInput,
     recording_metadata_author: HtmlInputElement => TextInput,
     recorder_mode: HtmlSelectElement => EnumInput<maia_json::RecorderMode>,
@@ -112,6 +113,7 @@ impl Ui {
             ad9361_rx_gain_mode,
             spectrometer_output_sampling_frequency,
             recording_metadata_filename,
+            recorder_prepend_timestamp,
             recording_metadata_description,
             recording_metadata_author,
             recorder_mode
@@ -163,6 +165,7 @@ impl Ui {
         maia_json::Recorder,
         maia_json::PatchRecorder,
         RECORDER_URL,
+        prepend_timestamp,
         mode
     );
 

--- a/maia-wasm/src/ui/input.rs
+++ b/maia-wasm/src/ui/input.rs
@@ -184,3 +184,34 @@ impl<E: std::str::FromStr + std::string::ToString> InputElement<HtmlSelectElemen
         self.element.set_value(&value.to_string());
     }
 }
+
+#[derive(Clone)]
+pub struct CheckboxInput {
+    element: Rc<HtmlInputElement>,
+}
+
+impl From<Rc<HtmlInputElement>> for CheckboxInput {
+    fn from(element: Rc<HtmlInputElement>) -> CheckboxInput {
+        CheckboxInput { element }
+    }
+}
+
+impl Deref for CheckboxInput {
+    type Target = HtmlInputElement;
+
+    fn deref(&self) -> &HtmlInputElement {
+        &self.element
+    }
+}
+
+impl InputElement<HtmlInputElement> for CheckboxInput {
+    type T = bool;
+
+    fn get(&self) -> Option<bool> {
+        Some(self.element.checked())
+    }
+
+    fn set(&self, &value: &bool) {
+        self.element.set_checked(value)
+    }
+}

--- a/maia-wasm/src/ui/macros.rs
+++ b/maia-wasm/src/ui/macros.rs
@@ -97,7 +97,12 @@ macro_rules! set_values_if_inactive {
         let mut preferences = $self.preferences.borrow_mut();
         paste::paste!{
             $(
-                if !$self.document.is_element_active(stringify!([<$section _ $element>])) {
+                // A checkbox HtmlInputElement is always considered inactive,
+                // because the user interaction with it is limited to clicking
+                // (rather than typing). Therefore, we update it regardless of
+                // whether it has focus.
+                if !$self.document.is_element_active(stringify!([<$section _ $element>]))
+                || $self.elements.[<$section _ $element>].type_() == "checkbox" {
                     $self.elements.[<$section _ $element>].set(&$source.$element);
                 }
                 if let Err(e) = preferences.[<update_ $section _ $element>](&$source.$element) {

--- a/maia-wasm/src/ui/preferences.rs
+++ b/maia-wasm/src/ui/preferences.rs
@@ -69,6 +69,7 @@ impl_preference_data! {
     ad9361_rx_gain: f64 = 70.0,
     spectrometer_output_sampling_frequency: f64 = 20.0,
     recording_metadata_filename: String = "recording".to_string(),
+    recorder_prepend_timestamp: bool = false,
     recording_metadata_description: String = "".to_string(),
     recording_metadata_author: String = "".to_string(),
     recorder_mode: maia_json::RecorderMode = maia_json::RecorderMode::IQ12bit,

--- a/maia-wasm/src/ui/preferences.rs
+++ b/maia-wasm/src/ui/preferences.rs
@@ -73,6 +73,7 @@ impl_preference_data! {
     recording_metadata_description: String = "".to_string(),
     recording_metadata_author: String = "".to_string(),
     recorder_mode: maia_json::RecorderMode = maia_json::RecorderMode::IQ12bit,
+    recorder_maximum_duration: f64 = 0.0,
 }
 
 impl Preferences {


### PR DESCRIPTION
This PR addresses the suggestions in #3.

Two features are added.

# Prepend timestamp to recording filename

This adds an option to prepend the date and time to the IQ recording filename.
    
A prepend_timestamp boolean field in the REST API controls whether prepending mode is active. In prepending mode, when a recording is started, the current filename is examined. If the beginning of the filename is formatted as a  timestamp, this timestamp is stripped. In other case, the filename is left as is. Next, the timestamp corresponding to the recording start (the same which is used for the SigMF metadata) is formatted as %Y-%m-%d-%H-%M-%S_ and prepended to the filename.

# Recording maximum duration

This adds a maximum duration field to the recorder REST API, which specifies the maximum duration for the next recording in seconds. A maximum duration of 0 indicates unlimited maximum duration (only limited by the RAM buffer size).
    
If the maximum duration is set to a value t > 0, the recording will be automatically stopped by maia-httpd after t + 0.1 seconds. The extra 0.1 seconds is added just in case the CPU timer is faster than the ADC sampling clock, or not very accurate, so that there is always the guarantee that at least the required number of samples have been recorded to RAM.
    
When the SigMF file is assembled for download, the SigMF file will be formed with exactly the number of samples corresponding to the maximum duration (this feature can even be used after the recording has been done, to "cut short" a longer recording).

----

The recording properties dialog now looks like this:

![ui_example](https://user-images.githubusercontent.com/15093841/227644702-785ba482-110a-4d7f-91cb-1f928eefd9eb.png)

----

Here is a `pluto.frm` firmware image in case anyone wants to try these changes:
[pluto.frm.zip](https://github.com/maia-sdr/maia-sdr/files/11066713/pluto.frm.zip)

@devnulling @jacobagilbert any feedback is more than welcome.
