### PR TITLE
adi-hdl: update to commit used in plutosdr-fw v0.36

### DIFF
--- a/maia-hdl/projects/pluto/system_project.tcl
+++ b/maia-hdl/projects/pluto/system_project.tcl
@@ -1,5 +1,5 @@
 
-source ../../adi-hdl/projects/scripts/adi_env.tcl
+source ../../adi-hdl/scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
 source $ad_hdl_dir/projects/scripts/adi_board.tcl
 


### PR DESCRIPTION
This bumps the adi-hdl submodule to the commit hash used in plutosdr-fw v0.36 and v0.37. There is no tag associated with this hash, but the branch is hdl_2021_R2. The corresponding version of Vivado is 2021.2

The path of the adi_env.tcl script has changed, so the maia-hdl pluto system_project.tcl has been updated accordingly.