### PR TITLE
ci: move maia-sdr-devel from docker hub to ghcr.io

### DIFF
--- a/.github/workflows/maia-hdl.yml
+++ b/.github/workflows/maia-hdl.yml
@@ -16,7 +16,7 @@ jobs:
     name: Python Tests
     runs-on: ubuntu-latest
     container:
-      image: maiasdr/maia-sdr-devel:latest
+      image: ghcr.io/maia-sdr/maia-sdr-devel:latest
       options: --user root
     steps:
     - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
     name: cocotb Tests
     runs-on: ubuntu-latest
     container:
-      image: maiasdr/maia-sdr-devel:latest
+      image: ghcr.io/maia-sdr/maia-sdr-devel:latest
       options: --user root
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Update the maia-hdl workflow to pull the image from ghcr.io.