### PR TITLE
maia-httpd: build against buildroot toolchain with cross

### DIFF
--- a/.github/workflows/maia-httpd.yml
+++ b/.github/workflows/maia-httpd.yml
@@ -42,7 +42,10 @@ jobs:
     - name: Build
       run: cross build --verbose --target armv7-unknown-linux-gnueabihf
     - name: Run tests
-      run: cross test --verbose --target armv7-unknown-linux-gnueabihf
+      # Tests don't work if we build against buildroot's uclibc, which is the default.
+      # Here we override the default and build against cross's default toolchain, for which
+      # the tests work.
+      run: cargo clean && CROSS_CONFIG=/dev/null cross test --verbose --target armv7-unknown-linux-gnueabihf
   x86_64:
     name: Rust test x86_64
     runs-on: ubuntu-latest

--- a/maia-httpd/Cross.toml
+++ b/maia-httpd/Cross.toml
@@ -1,0 +1,2 @@
+[target.armv7-unknown-linux-gnueabihf]
+image = "ghcr.io/maia-sdr/cross-armv7-buildroot-linux-uclibc-gnueabihf"

--- a/maia-httpd/README.md
+++ b/maia-httpd/README.md
@@ -9,6 +9,19 @@ maia-httpd is a Rust crate that implements the HTTP server used in [Maia
 SDR](https://maia-sdr.org/). This web server runs on the Zynq ARM CPU and
 streams data to web browsers running on a client device.
 
+## Building
+
+In order to simplify building maia-httpd for the [Pluto SDR
+firmware](https://github.com/maia-sdr/plutosdr-fw), which uses a buildroot
+uclibc toolchain, a custom Docker image can be used to build against this
+toolchain with [cross](https://github.com/cross-rs/cross). This image is already
+configured in `Cross.toml`.
+
+The crate can be built as
+```
+cross build --release --target armv7-unknown-linux-gnueabihf
+```
+
 ## API documentation
 
 The API documentation is hosted in [docs.rs](https://docs.rs/maia-httpd/).


### PR DESCRIPTION
This uses a custom Docker image (taken from the maia-sdr-docker repository) to build against the buildroot uclibc toolchain using cross.