### PR TITLE
bump to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-03-26
+
+### Changed
+
+- Bumped maia-hdl to v0.1.1. Updated adi-hdl submodule to Vivado 2021.2 branch.
+
 ## [0.2.0] - 2023-03-18
 
 ### Changed
@@ -33,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   interface with real-time waterfall display and IQ recording in SigMF format to
   the Pluto RAM.
 
-[unreleased]: https://github.com/maia-sdr/maia-sdr/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/maia-sdr/maia-sdr/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/maia-sdr/maia-sdr/compare/v0.2.0...maia-sdr-v0.2.1
 [0.2.0]: https://github.com/maia-sdr/maia-sdr/compare/v0.1.0...maia-sdr-v0.2.0
 [0.1.0]: https://github.com/maia-sdr/maia-sdr/releases/tag/v0.1.0

--- a/maia-hdl/CHANGELOG.md
+++ b/maia-hdl/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2023-03-26
+
+### Changed
+
+- Updated adi-hdl submodule to branch used in ADI Pluto firmware v0.36, which is uses
+  Vivado 2021.2.
+
 ## [0.1.0] - 2023-02-10
 
 ### Added

--- a/maia-hdl/maia_hdl/maia_sdr.py
+++ b/maia-hdl/maia_hdl/maia_sdr.py
@@ -20,7 +20,7 @@ from .recorder import Recorder12IQ
 from .spectrometer import Spectrometer
 
 # IP core version
-_version = '0.1.0'
+_version = '0.1.1'
 
 
 class MaiaSDR(Elaboratable):

--- a/maia-hdl/pyproject.toml
+++ b/maia-hdl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maia_hdl"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="Daniel Estevez", email="daniel@destevez.net" },
 ]


### PR DESCRIPTION
Bumps maia-hdl to v0.1.1 due to the update of adi-hdl to the Vivado 2021.2 branch.