### PR TITLE
ci: fix plutosdr-fw PR comment in PRs from forks

### DIFF
--- a/.github/workflows/plutosdr-fw-pr-comment.yml
+++ b/.github/workflows/plutosdr-fw-pr-comment.yml
@@ -1,0 +1,22 @@
+name: 'plutosdr-fw-pr-comment'
+on:
+  workflow_run:
+    workflows: ['plutosdr-fw']
+    types:
+      - completed
+
+jobs:
+  pr-comment:
+    name: Add PR comment
+    needs: build-firmware
+    runs-on: ubuntu-latest
+    if: $${{ github.event.pull_requests.length > 0 }}
+    steps:
+    - name: Add comment to PR with link to artifacts
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        body: |
+          The Pluto SDR firmware image for this pull request is ready.
+          
+          Find it under "Artifacts" in the [action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}).
+        issue-number: ${{ github.event.pull_requests[0].number }}

--- a/.github/workflows/plutosdr-fw.yml
+++ b/.github/workflows/plutosdr-fw.yml
@@ -47,15 +47,6 @@ jobs:
         path: |
           build/pluto.dfu
           build/pluto.frm
-    - name: Add comment to PR with link to artifacts
-      uses: peter-evans/create-or-update-comment@v2
-      if: ${{ github.event_name == 'pull_request' }}
-      with:
-        body: |
-          The Pluto SDR firmware image for this pull request is ready.
-          
-          Find it under "Artifacts" in the [action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-        issue-number: ${{ github.event.pull_request.number }}
     - name: Create Pre-release
       if: ${{ github.event_name != 'pull_request' }}
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The current approach doesn't work because we can't make comments from a pull_request triggered PR. We use another workflow that triggers when the main workflow has completed.