### PR TITLE
ci: fix plutosdr-fw-pr-comment

### DIFF
--- a/.github/workflows/plutosdr-fw-pr-comment.yml
+++ b/.github/workflows/plutosdr-fw-pr-comment.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   pr-comment:
     name: Add PR comment
-    needs: build-firmware
     runs-on: ubuntu-latest
     if: $${{ github.event.pull_requests.length > 0 }}
     steps:


### PR DESCRIPTION
There was a stray dependency in the job, which made the workflow malformed.