### PR TITLE
ci:pluto: ignore prerelease tags when fetching XSA

### DIFF
--- a/.github/workflows/plutosdr-fw.yml
+++ b/.github/workflows/plutosdr-fw.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Fetch Pluto XSA
       run: |
         cd maia-sdr
-        LATEST_TAG=$(git describe --abbrev=0 --tags)
+        LATEST_TAG=$(git describe --abbrev=0 --tags --exclude '*-prerelease')
         wget -T 3 -t 1 -N http://github.com/maia-sdr/maia-sdr/releases/download/${LATEST_TAG}/pluto_system_top.xsa
     - name: Build firmware
       run: |


### PR DESCRIPTION
The plutosdr-fw-prerelease tag doesn't have an XSA asset, so the action is currently failing in this step.