### PR TITLE
ci: add debug to plutosdr-fw-pr-comment workflow

### DIFF
--- a/.github/workflows/plutosdr-fw-pr-comment.yml
+++ b/.github/workflows/plutosdr-fw-pr-comment.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.pull_requests[0] != null
     steps:
+    - name: Print Github context (for debugging)
+      run: echo '${{ toJSON(github) }}'
     - name: Add comment to PR with link to artifacts
       uses: peter-evans/create-or-update-comment@v2
       with:


### PR DESCRIPTION
This adds a debug print to the workflow, since it is being skipped when it shouldn't.