### PR TITLE
ci: fix debug statement in plutosdr-fw-pr-comment

### DIFF
--- a/.github/workflows/plutosdr-fw-pr-comment.yml
+++ b/.github/workflows/plutosdr-fw-pr-comment.yml
@@ -9,11 +9,11 @@ jobs:
   pr-comment:
     name: Add PR comment
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.pull_requests[0] != null
     steps:
     - name: Print Github context (for debugging)
       run: echo '${{ toJSON(github) }}'
     - name: Add comment to PR with link to artifacts
+      if: github.event.workflow_run.pull_requests[0] != null
       uses: peter-evans/create-or-update-comment@v2
       with:
         issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
Move the 'if' to the step that adds the comment. Otherwise the debug will never print if the step is skipped.