### PR TITLE
ci: use get-workflow-origin in pluto-sdr-fw-pr-comment

### DIFF
--- a/.github/workflows/plutosdr-fw-pr-comment.yml
+++ b/.github/workflows/plutosdr-fw-pr-comment.yml
@@ -8,17 +8,20 @@ on:
 jobs:
   pr-comment:
     name: Add PR comment
+    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - name: Print Github context (for debugging)
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
+    - name: Get pull_request info
+      uses: potiuk/get-workflow-origin@v1_5
+      id: workflow-run-info
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        sourceRunId: ${{ github.event.workflow_run.id }}
     - name: Add comment to PR with link to artifacts
       if: github.event.workflow_run.pull_requests[0] != null
       uses: peter-evans/create-or-update-comment@v2
       with:
-        issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+        issue-number: ${{ steps.workflow-run-info.outputs.pullRequestNumber }}
         body: |
           The Pluto SDR firmware image for this pull request is ready.
           


### PR DESCRIPTION
Try to get the PR number using the get-workflow-origin action.

Using the github context to get the PR number in a workflow_run triggered workflow is unreliable, as documented in https://github.com/orgs/community/discussions/25220 We use the workaround mentioned in
https://github.com/orgs/community/discussions/25220#discussioncomment-3246923