### PR TITLE
ci: remove stray 'if:' in plutosdr-fw-pr-comment

### DIFF
--- a/.github/workflows/plutosdr-fw-pr-comment.yml
+++ b/.github/workflows/plutosdr-fw-pr-comment.yml
@@ -18,7 +18,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         sourceRunId: ${{ github.event.workflow_run.id }}
     - name: Add comment to PR with link to artifacts
-      if: github.event.workflow_run.pull_requests[0] != null
       uses: peter-evans/create-or-update-comment@v2
       with:
         issue-number: ${{ steps.workflow-run-info.outputs.pullRequestNumber }}


### PR DESCRIPTION
The correct 'if:' is applied to the job globally, so we don't need this 'if:' in the step anymore.