### PR TITLE
ci: some updates

### DIFF
--- a/.github/workflows/maia-httpd.yml
+++ b/.github/workflows/maia-httpd.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   armv7:
-    name: Rust armv7
+    name: Build and test (armv7)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
         cargo build --verbose --target armv7-unknown-linux-gnueabihf \
           --config target.armv7-unknown-linux-gnueabihf.linker=\"arm-linux-gnueabihf-gcc\"
   armv7_cross:
-    name: Rust armv7 (with cross)
+    name: Build and test (armv7 with cross)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -47,9 +47,17 @@ jobs:
       # the tests work.
       run: cargo clean && CROSS_CONFIG=/dev/null cross test --verbose --target armv7-unknown-linux-gnueabihf
   x86_64:
-    name: Rust test x86_64
+    name: Build and test (x86_64)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: cargo test
       run: cargo test --verbose
+  publish:
+    if: startsWith(github.event.ref, 'refs/tags/maia-httpd-')
+    needs: [armv7, armv7_cross, x86_64]
+    uses: ./.github/workflows/publish.yml
+    with:
+      path: maia-httpd
+    secrets:
+      registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/maia-json.yml
+++ b/.github/workflows/maia-json.yml
@@ -9,8 +9,8 @@ defaults:
     working-directory: maia-httpd/maia-json
 
 jobs:
-  rust:
-    name: Rust x86_64
+  build-test:
+    name: Build and test (x86_64)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -24,3 +24,11 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+  publish:
+    if: startsWith(github.event.ref, 'refs/tags/maia-json-')
+    needs: build-test
+    uses: ./.github/workflows/publish.yml
+    with:
+      path: maia-httpd/maia-json
+    secrets:
+      registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/maia-pac.yml
+++ b/.github/workflows/maia-pac.yml
@@ -1,0 +1,13 @@
+name: 'maia-pac'
+on:
+  push:
+    tags:
+      - maia-pac-**
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish.yml
+    with:
+      path: maia-httpd/maia-pac
+    secrets:
+      registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/maia-wasm.yml
+++ b/.github/workflows/maia-wasm.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   wasm:
-    name: Rust wasm
+    name: Build and test (wasm)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -27,9 +27,17 @@ jobs:
     - name: Build with wasm-pack
       run: wasm-pack build --target web
   x86_64:
-    name: Rust test x86_64
+    name: Build and test (x86_64)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: cargo test
       run: cargo test --verbose
+  publish:
+    if: startsWith(github.event.ref, 'refs/tags/maia-wasm-')
+    needs: [wasm, x86_64]
+    uses: ./.github/workflows/publish.yml
+    with:
+      path: maia-wasm
+    secrets:
+      registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/plutosdr-fw.yml
+++ b/.github/workflows/plutosdr-fw.yml
@@ -47,8 +47,19 @@ jobs:
         path: |
           build/pluto.dfu
           build/pluto.frm
+  create-pre-release:
+    name: Create pre-realease
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    needs: build-fw
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: pluto-firmware
+    - name: Show directory tree (debug)
+      run: ls -R
     - name: Delete previous pre-release
-      if: github.event_name != 'pull_request'
       uses: dev-drprasad/delete-tag-and-release@v0.2.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -56,12 +67,11 @@ jobs:
         tag_name: plutosdr-fw-prerelease
         delete_release: true
     - name: Create new pre-release
-      if: github.event_name != 'pull_request'
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          build/pluto.dfu
-          build/pluto.frm
+          pluto.dfu
+          pluto.frm
         name: Maia SDR main branch Pluto SDR firmware (experimental)
         prerelease: true
         tag_name: plutosdr-fw-prerelease

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+on:
+  workflow_call:
+    inputs:
+      path:
+        required: true
+        type: string
+    secrets:
+      registry-token:
+        required: true
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.registry-token }}
+          path: ${{ inputs.path }}


### PR DESCRIPTION
Splits the pluto-fw workflow into two jobs to avoid rebuilding the firmware if the release creation fails, and adds actions to publish the Rust crates to crates.io on tag pushes.