### PR TITLE
ci:plutosdr-fw: fix latest XSA discovery

### DIFF
--- a/.github/workflows/plutosdr-fw.yml
+++ b/.github/workflows/plutosdr-fw.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Fetch Pluto XSA
       run: |
         cd maia-sdr
-        LATEST_TAG=$(git describe --abbrev=0 --tags --exclude '*-prerelease')
+        LATEST_TAG=$(git describe --abbrev=0 --tags --match 'v*')
         wget -T 3 -t 1 -N http://github.com/maia-sdr/maia-sdr/releases/download/${LATEST_TAG}/pluto_system_top.xsa
     - name: Build firmware
       run: |


### PR DESCRIPTION
Now that we have tags such as maia-json-..., we need to change the way that the latests maia-sdr tag is found.