### PR TITLE
ci:plutosdr-fw: do not delete previous pre-release

### DIFF
--- a/.github/workflows/plutosdr-fw.yml
+++ b/.github/workflows/plutosdr-fw.yml
@@ -59,13 +59,13 @@ jobs:
         name: pluto-firmware
     - name: Show directory tree (debug)
       run: ls -R
-    - name: Delete previous pre-release
+    - name: Delete plutosdr-fw-prerelease tag
       uses: dev-drprasad/delete-tag-and-release@v0.2.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: plutosdr-fw-prerelease
-        delete_release: true
+        delete_release: false
     - name: Create new pre-release
       uses: softprops/action-gh-release@v1
       with:


### PR DESCRIPTION
Try to delete only the pre-release tag to avoid the new pre-released being in a draft state after the action finishes.