### PR TITLE
v0.5.0 release: fix timing in v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0] - 2023-07-09
+## [0.5.0] - 2023-07-08
+
+- Bumped maia-hdl to v0.3.0. Timing improvement.
+
+## [0.4.0] - 2023-07-08
 
 - Bumped maia-hdl to v0.2.0. Added support for Pluto+.
 

--- a/maia-hdl/CHANGELOG.md
+++ b/maia-hdl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-07-08
+
+### Changed
+
+- Register output of ClkNxCommonEdge to improve timing (API-breaking change).
+
 ## [0.2.0] - 2023-07-08
 
 ### Added

--- a/maia-hdl/maia_hdl/maia_sdr.py
+++ b/maia-hdl/maia_hdl/maia_sdr.py
@@ -160,9 +160,9 @@ class MaiaSDR(Elaboratable):
             's_axi_lite', 'sync', self.sdr_registers.aw)
 
         m.submodules.common_edge_2x = common_edge_2x = ClkNxCommonEdge(
-            'sync', 'clk2x')
+            'sync', 'clk2x', 2)
         m.submodules.common_edge_3x = common_edge_3x = ClkNxCommonEdge(
-            'sync', 'clk3x')
+            'sync', 'clk3x', 3)
 
         # RX IQ CDC
         m.submodules.rxiq_cdc = rxiq_cdc = RxIQCDC('sampling', 'sync', 12)

--- a/maia-hdl/maia_hdl/maia_sdr.py
+++ b/maia-hdl/maia_hdl/maia_sdr.py
@@ -20,7 +20,7 @@ from .recorder import Recorder12IQ
 from .spectrometer import Spectrometer
 
 # IP core version
-_version = '0.2.0'
+_version = '0.3.0'
 
 
 class MaiaSDR(Elaboratable):

--- a/maia-hdl/pyproject.toml
+++ b/maia-hdl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maia_hdl"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
   { name="Daniel Estevez", email="daniel@destevez.net" },
 ]

--- a/maia-hdl/test_cocotb/cmult3x/verilog.py
+++ b/maia-hdl/test_cocotb/cmult3x/verilog.py
@@ -24,7 +24,7 @@ class Tb(Elaboratable):
         m = Module()
         m.submodules.dut = self.dut
         m.submodules.common_edge = common_edge = ClkNxCommonEdge(
-            'sync', self.clk3x)
+            'sync', self.clk3x, 3)
         m.d.comb += self.dut.common_edge.eq(common_edge.common_edge)
         return m
 


### PR DESCRIPTION
This makes a change in the `ClkNxCommonEdge` module to improve timing, since release v0.4.0 was not closing timing when building the Pluto bitstream.