### PR TITLE
ci: replace plutosdr-fw runner by self-hosted

### DIFF
--- a/.github/workflows/plutosdr-fw.yml
+++ b/.github/workflows/plutosdr-fw.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-fw:
     name: Build Pluto SDR firmware
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, vivado]
     container:
       image: ghcr.io/maia-sdr/maia-sdr-devel:latest
       options: --user root


### PR DESCRIPTION
This is the first test to get building the PlutoSDR firmware with Vivado running on a self-hosted runner.