### PR TITLE
ci: build plutosdr-fw without XSA file

### DIFF
--- a/.github/workflows/plutosdr-fw.yml
+++ b/.github/workflows/plutosdr-fw.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: [self-hosted, vivado]
     container:
       image: ghcr.io/maia-sdr/maia-sdr-devel:latest
+      volumes:
+        - vivado2021_2:/opt/Xilinx
       options: --user root
     steps:
     - name: Checkout plutosdr-fw
@@ -29,17 +31,27 @@ jobs:
         # need to fetch history to get the latest tag with git describe
         fetch-depth: 0
         submodules: recursive
-    - name: Fetch Pluto XSA
-      run: |
-        cd maia-sdr
-        LATEST_TAG=$(git describe --abbrev=0 --tags --match 'v*')
-        wget -T 3 -t 1 -N http://github.com/maia-sdr/maia-sdr/releases/download/${LATEST_TAG}/pluto_system_top.xsa
     - name: Build firmware
+      # xsct, which is run by the make process, uses Xvfb, which usually needs a
+      # connection to an X server (even though it is a CLI application). We run
+      # Xvfb in the container to create a "fake" X session that makes xsct
+      # happy.
+      #
+      # We cannot '.' the main settings.sh file for Vivado, because it uses
+      # 'source' to run the sub-files, and we are not using bash. Instead, we
+      # '.' each individual sub-file.
       run: |
+        . /opt/Xilinx/Vitis/2021.2/.settings64-Vitis.sh
+        . /opt/Xilinx/Vivado/2021.2/.settings64-Vivado.sh
+        . /opt/Xilinx/Vitis_HLS/2021.2/.settings64-Vitis_HLS.sh
         . /opt/rust/env
         export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin/:/usr/bin:/sbin:/bin:/opt/gcc-arm-linux-gnueabi/bin:$PATH:/opt/oss-cad-suite/bin
         export PYTHONPATH=/usr/local/lib/python3.10/dist-packages
-        XSA_FILE=maia-sdr/pluto_system_top.xsa make
+        apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb
+        Xvfb :10 &
+        export DISPLAY=:10
+        make
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -47,3 +59,8 @@ jobs:
         path: |
           build/pluto.dfu
           build/pluto.frm
+    # The working directory in the self-hosted runner needs be cleaned before
+    # building. We use if: ${{ always() }} to clean even if the build fails.
+    - name: Clean up runner working dir
+      uses: TooMuch4U/actions-clean@v2.1
+      if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Stable releases of firmware images for the ADALM Pluto can be found in the
 [plutosdr-fw](https://github.com/maia-sdr/plutosdr-fw) repository. See also the
 [installation instructions](https://maia-sdr.org/installation/).
 
-Experimental ADALM Pluto firmware images are built automatically with Github's
-actions system. To download the firmware image for the latest commit in the
-`main` branch (or for any other commit), click on the actions check, then go to
-the `plutosdr-fw` action details, click on the summary, and download the
-`pluto-firmware` artifact. This procedure is illustrated by the following
-screenshots.
+Development ADALM Pluto firmware images for each commit and pull request are
+built automatically with Github's actions system. To download the firmware image
+for the latest commit in the `main` branch (or for any other commit), click on
+the actions check, then go to the `plutosdr-fw` action details, click on the
+summary, and download the `pluto-firmware` artifact. This procedure is
+illustrated by the following screenshots.
 
 ![List of actions](readme-images/fw-artifact-1.png)
 
@@ -34,14 +34,6 @@ screenshots.
 
 For each pull request, a firmware image is also built. The bot adds a comment to
 the pull request with a link to the firmware when it is ready.
-
-Note that the process for building firmware images with Github actions is
-currently experimental and that the FPGA image is not built, because it is not
-possible to run Vivado in a Github-hosted runner. The actions system will take
-the latest XSA file published as an asset in a maia-sdr release. This may or may
-not work with the current state of the `main` branch or a particular pull
-request. The main goal of this system is to allow people to preview and test new
-features before they make it into stable releases.
 
 ## Support
 


### PR DESCRIPTION
This uses Vivado to build the bitstream and FSBL instead of using the bitstream in a pre-built XSA file.