### PR TITLE
maia-httpd,maia-wasm: optimize code generation

### DIFF
--- a/maia-httpd/.cargo/config.toml
+++ b/maia-httpd/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.armv7-unknown-linux-gnueabihf]
+rustflags = ["-C", "target-feature=+v7,+neon,+vfp2,+vfp3", "-C", "target-cpu=cortex-a9"]

--- a/maia-httpd/Cargo.toml
+++ b/maia-httpd/Cargo.toml
@@ -40,5 +40,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [profile.release]
+codegen-units = 1
 lto = true
 strip = "debuginfo"

--- a/maia-wasm/Cargo.toml
+++ b/maia-wasm/Cargo.toml
@@ -64,4 +64,5 @@ features = [
 ]
 
 [profile.release]
+codegen-units = 1
 lto = true

--- a/maia-wasm/waterfall-example/Cargo.toml
+++ b/maia-wasm/waterfall-example/Cargo.toml
@@ -27,4 +27,5 @@ features = [
 ]
 
 [profile.release]
+codegen-units = 1
 lto = true


### PR DESCRIPTION
Use codegen-units=1 in maia-httpd and maia-wasm. Use CPU flags for the Zynq Cortex A9 in maia-httpd.