### PR TITLE
maia-httpd: fix sigmf version format

### DIFF
--- a/maia-httpd/src/sigmf.rs
+++ b/maia-httpd/src/sigmf.rs
@@ -5,7 +5,7 @@
 use chrono::prelude::*;
 use serde_json::json;
 
-const SIGMF_VERSION: &str = "v1.0.0";
+const SIGMF_VERSION: &str = "1.0.0";
 const SIGMF_RECORDER: &str = concat!("Maia SDR v", env!("CARGO_PKG_VERSION"));
 
 /// SigMF metadata.


### PR DESCRIPTION
According to https://github.com/sigmf/SigMF/pull/298 the SigMF version should not have a leading `v`.