### PR TITLE
maia-wasm: fix clippy lints

### DIFF
--- a/maia-wasm/src/ui.rs
+++ b/maia-wasm/src/ui.rs
@@ -374,7 +374,6 @@ impl Ui {
     fn patch_recorder_promise(&self, patch: maia_json::PatchRecorder) -> JsValue {
         let ui = self.clone();
         future_to_promise(async move {
-            let patch = patch;
             match ui.patch_recorder(&patch).await {
                 Ok(json_output) => ui.update_recorder_button(&json_output),
                 Err(PatchError::RequestFailed(_)) => {

--- a/maia-wasm/src/ui/macros.rs
+++ b/maia-wasm/src/ui/macros.rs
@@ -215,7 +215,6 @@ macro_rules! impl_onchange {
                         let patch = $patch_json { $element: Some(value), ..Default::default() };
                         let ui = ui.clone();
                         future_to_promise(async move {
-                            let patch = patch;
                             ui.[<patch_ $name _update_elements>](&patch).await?;
                             Ok(JsValue::NULL)
                         }).into()


### PR DESCRIPTION
Some clippy lints have appeared in the latest version of the Rust toolchain. These lints are above an unncessary
 let patch = patch;

This was used before because it is necessary to move patch into the async block, but the block only depends on &patch, so the compiler didn't seem smart enough to figure out the need to make the move on its own. Apparently now it does and the let is redundant.