### PR TITLE
Add IQEngine

### DIFF
--- a/maia-httpd/Cargo.lock
+++ b/maia-httpd/Cargo.lock
@@ -742,6 +742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912b45c753ff5f7f5208307e8ace7d2a2e30d024e26d3509f3dce546c044ce15"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "maia-httpd"
 version = "0.3.2"
 dependencies = [
@@ -754,8 +763,10 @@ dependencies = [
  "http",
  "hyper",
  "libc",
+ "lz4_flex",
  "maia-json",
  "maia-pac",
+ "mime_guess",
  "nix",
  "page_size",
  "paste",
@@ -1240,6 +1251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +1543,16 @@ dependencies = [
  "thiserror",
  "url",
  "utf-8",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/maia-httpd/Cargo.toml
+++ b/maia-httpd/Cargo.toml
@@ -24,8 +24,10 @@ futures = "0.3"
 http = "1.0"
 hyper = "1.1"
 libc = "0.2"
+lz4_flex = { version = "0.11.2", features = ["frame"], default-features = true }
 maia-json = { path = "maia-json", version = "0.3.0" }
 maia-pac = { path = "maia-pac", version = "0.3.0"  }
+mime_guess = "2"
 nix = { version = "0.27", features = ["ioctl", "time"] }
 page_size = "0.6"
 paste = "1.0"

--- a/maia-httpd/src/httpd/iqengine.rs
+++ b/maia-httpd/src/httpd/iqengine.rs
@@ -1,0 +1,27 @@
+use super::json_error::JsonError;
+use anyhow::Result;
+use axum::{extract::Path, http::header, response::IntoResponse};
+use std::io::Read;
+
+pub async fn decompress_asset(filename: &str) -> Result<impl IntoResponse> {
+    let path = std::path::Path::new("iqengine").join(format!("{}.lz4", filename));
+    let compressed = tokio::fs::read(path).await?;
+    let decompressed = tokio::task::spawn_blocking(move || -> Result<Vec<u8>> {
+        let mut decoder = lz4_flex::frame::FrameDecoder::new(&compressed[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed)?;
+        Ok(decompressed)
+    })
+    .await??;
+    let mime = mime_guess::from_path(filename).first_or_octet_stream();
+    Ok((
+        [(header::CONTENT_TYPE, mime.as_ref().to_string())],
+        decompressed,
+    ))
+}
+
+pub async fn serve_assets(Path(filename): Path<String>) -> Result<impl IntoResponse, JsonError> {
+    decompress_asset(&filename)
+        .await
+        .map_err(JsonError::server_error)
+}

--- a/maia-httpd/src/httpd/recording/iqengine.rs
+++ b/maia-httpd/src/httpd/recording/iqengine.rs
@@ -1,0 +1,149 @@
+use super::super::json_error::JsonError;
+use super::{unpack_12bit_to_16bit, Recorder, RecorderMode, RecordingBuffer, RecordingBufferInfo};
+use anyhow::Result;
+use axum::extract::{Query, State};
+use bytes::{Bytes, BytesMut};
+use serde_json::json;
+use std::collections::HashMap;
+
+async fn get_meta(recorder: &Recorder) -> Result<serde_json::Value> {
+    let metadata = recorder.metadata.lock().await.clone();
+    let mut meta = metadata.sigmf_meta.to_json_value();
+
+    // compute recording length
+    let recorder_next_address = recorder.ip_core.lock().unwrap().recorder_next_address();
+    let buffer_info =
+        RecordingBufferInfo::new(metadata.mode, recorder_next_address, metadata.max_samples())
+            .await?;
+    let sample_length = buffer_info.num_items();
+
+    // add traceability, which is required by IQEngine
+    let global = meta.get_mut("global").unwrap().as_object_mut().unwrap();
+    global.insert("traceability:revision".to_string(), json!(0));
+    global.insert(
+        "traceability:origin".to_string(),
+        json!({
+            "type": "api",
+            "account": "maiasdr",
+            "container": "maiasdr",
+            "file_path": "recording",
+        }),
+    );
+    global.insert(
+        "traceability:sample_length".to_string(),
+        json!(sample_length),
+    );
+    Ok(meta)
+}
+
+pub async fn meta(State(recorder): State<Recorder>) -> Result<String, JsonError> {
+    get_meta(&recorder)
+        .await
+        .map_err(JsonError::server_error)
+        .map(|r| serde_json::to_string(&r).unwrap())
+}
+
+async fn get_iq_data(
+    recorder: &Recorder,
+    block_indexes: &[usize],
+    block_size: usize,
+) -> Result<Bytes> {
+    let metadata = recorder.metadata.lock().await.clone();
+    let recorder_next_address = recorder.ip_core.lock().unwrap().recorder_next_address();
+    let buffer =
+        RecordingBuffer::new(metadata.mode, recorder_next_address, metadata.max_samples()).await?;
+
+    let bytes_per_input = buffer.info.input_bytes_per_item;
+    let bytes_per_output = buffer.info.mode.output_bytes_per_item();
+    let mut bytes = BytesMut::with_capacity(block_indexes.len() * block_size * bytes_per_output);
+    for &idx in block_indexes {
+        let start = idx * block_size * bytes_per_input;
+        let len = block_size * bytes_per_input;
+        if start + len >= buffer.info.size {
+            anyhow::bail!("requested data is out of bounds");
+        }
+        let data = unsafe { std::slice::from_raw_parts(buffer.base.add(start), len) };
+        match buffer.info.mode.0 {
+            RecorderMode::IQ8bit => bytes.extend_from_slice(data),
+            RecorderMode::IQ12bit => {
+                let len0 = bytes.len();
+                bytes.resize(len0 + block_size * bytes_per_output, 0);
+                unpack_12bit_to_16bit(&mut bytes[len0..], data);
+            }
+        }
+    }
+
+    Ok(bytes.into())
+}
+
+async fn get_iq_data_params(
+    recorder: &Recorder,
+    params: &HashMap<String, String>,
+) -> Result<Bytes> {
+    let block_indexes_str = params
+        .get("block_indexes_str")
+        .ok_or_else(|| anyhow::anyhow!("block_indexes_str missing"))?;
+    let mut block_indexes = Vec::new();
+    for w in block_indexes_str.split(',') {
+        block_indexes.push(w.parse()?);
+    }
+    let block_size = params
+        .get("block_size")
+        .ok_or_else(|| anyhow::anyhow!("block_size missing"))?
+        .parse()?;
+    get_iq_data(recorder, &block_indexes, block_size).await
+}
+
+pub async fn iq_data(
+    State(recorder): State<Recorder>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Bytes, JsonError> {
+    get_iq_data_params(&recorder, &params)
+        .await
+        .map_err(JsonError::server_error)
+}
+
+// See
+// https://github.com/IQEngine/IQEngine/blob/main/api/app/iq_router.py#L213
+// for details
+async fn get_minimap_data(recorder: &Recorder) -> Result<Bytes> {
+    const FFT_SIZE: usize = 64;
+    const NUM_FFTS: usize = 1000;
+
+    let metadata = recorder.metadata.lock().await.clone();
+    let recorder_next_address = recorder.ip_core.lock().unwrap().recorder_next_address();
+    let buffer =
+        RecordingBuffer::new(metadata.mode, recorder_next_address, metadata.max_samples()).await?;
+
+    let bytes_per_input = buffer.info.input_bytes_per_item;
+    let bytes_per_output = buffer.info.mode.output_bytes_per_item();
+
+    let total_ffts = buffer.info.num_items() / FFT_SIZE;
+
+    let mut bytes = BytesMut::with_capacity(NUM_FFTS * FFT_SIZE * bytes_per_output);
+    for j in 0..NUM_FFTS {
+        let idx = j * total_ffts / NUM_FFTS;
+        let start = idx * FFT_SIZE * bytes_per_input;
+        let len = FFT_SIZE * bytes_per_input;
+        if start + len >= buffer.info.size {
+            anyhow::bail!("requested data is out of bounds");
+        }
+        let data = unsafe { std::slice::from_raw_parts(buffer.base.add(start), len) };
+        match buffer.info.mode.0 {
+            RecorderMode::IQ8bit => bytes.extend_from_slice(data),
+            RecorderMode::IQ12bit => {
+                let len0 = bytes.len();
+                bytes.resize(len0 + FFT_SIZE * bytes_per_output, 0);
+                unpack_12bit_to_16bit(&mut bytes[len0..], data);
+            }
+        }
+    }
+
+    Ok(bytes.into())
+}
+
+pub async fn minimap_data(State(recorder): State<Recorder>) -> Result<Bytes, JsonError> {
+    get_minimap_data(&recorder)
+        .await
+        .map_err(JsonError::server_error)
+}

--- a/maia-httpd/src/sigmf.rs
+++ b/maia-httpd/src/sigmf.rs
@@ -225,7 +225,17 @@ impl Metadata {
     ///
     /// The formatting of the JSON is compliant with the SigMF standard.
     pub fn to_json(&self) -> String {
-        let json = json!({
+        let json = self.to_json_value();
+        let mut s = serde_json::to_string_pretty(&json).unwrap();
+        s.push('\n'); // to_string_pretty does not include a final \n
+        s
+    }
+
+    /// Returns a JSON [`serde_json::Value`] that represents the metadata in JSON.
+    ///
+    /// The formatting of the JSON is compliant with the SigMF standard.
+    pub fn to_json_value(&self) -> serde_json::Value {
+        json!({
             "global": {
                 "core:datatype": self.datatype.to_string(),
                 "core:version": SIGMF_VERSION,
@@ -242,10 +252,7 @@ impl Metadata {
                 }
             ],
             "annotations": []
-        });
-        let mut s = serde_json::to_string_pretty(&json).unwrap();
-        s.push('\n'); // to_string_pretty does not include a final \n
-        s
+        })
     }
 }
 

--- a/maia-wasm/assets/index.html
+++ b/maia-wasm/assets/index.html
@@ -37,6 +37,7 @@
         </select>
         <label for="recorder_maximum_duration">Max duration (s)</label>
         <input type="number" min="0" step="any" id="recorder_maximum_duration">
+        <a id="iqengine_recording" href="/view/api/maiasdr/maiasdr/recording">View in IQEngine</a>
         <a id="download_recording" href="/recording" download>Download recording</a>
         <button id="close_recording_dialog" value="close" autofocus>Close</button>
       </form>

--- a/maia-wasm/assets/style.css
+++ b/maia-wasm/assets/style.css
@@ -240,7 +240,7 @@ input.gain {
 #recording_form input,
 #recording_form select,
 #recording_form .recording_filename_properties {
-    grid-column: 2/5;
+    grid-column: 2/6;
 }
 
 .recording_filename_properties {
@@ -253,14 +253,19 @@ input.gain {
     flex: 1;
 }
 
-#download_recording {
+#iqengine_recording {
     grid-column: 3/4;
 }
 
-#close_recording_dialog {
+#download_recording {
     grid-column: 4/5;
 }
 
+#close_recording_dialog {
+    grid-column: 5/6;
+}
+
+#iqengine_recording,
 #download_recording {
     color: var(--text-color);
     text-decoration: none;
@@ -270,6 +275,7 @@ input.gain {
     background-color: var(--button-color);
 }
 
+#iqengine_recording:hover,
 #download_recording:hover {
     background-color: var(--button-highlight-color);
 }


### PR DESCRIPTION
This PR adds to maia-httpd and maia-wasm the changes required to add IQEngine as a viewer for the IQ recording stored on the Pluto DDR.

The way in which this works is by implementing some of the IQEngine backend API methods in maia-httpd. The IQEngine client is compressed using lz4 to save ramfs space and served by maia-httpd. When the IQEngine client is fetched by the web browser, it starts talking to maia-httpd believing that it is a regular IQEngine backend. The IQEngine API methods in maia-httpd return IQ samples / metadata corresponding to the recording done to the DDR by Maia SDR.

Previously each request to get IQ data from the recording involved `mmap()`ing the recording and performing cache invalidation of the whole recording. This is not a good approach for IQEngine, because it performs many separate queries to get pieces of IQ data, and invalidating the cache is time consuming. `mmap()`ing a large file is also time consuming, since it involves creating page tables. Instead, a shared "global" `mmap()` is held by the application, and this is used to serve all the queries. When a new recording is done, the old `mmap()` is unmapped and a new `mmap()` is done. This invalidates the cache. The "global" `mmap()` is managed with a `RwLock`, which prevents getting IQ data while a recording is in progress or starting a recording while IQ data is being retrieved.