### PR TITLE
ci: update checkout actions to v4

### DIFF
--- a/.github/workflows/maia-hdl.yml
+++ b/.github/workflows/maia-hdl.yml
@@ -6,7 +6,7 @@ jobs:
     name: Check Python Formatting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install pycodestyle with pip
       run: pip install pycodestyle
     - name: Run pycodestyle
@@ -19,7 +19,7 @@ jobs:
       image: ghcr.io/maia-sdr/maia-sdr-devel:latest
       options: --user root
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run Python unittest
       run: |
         cd maia-hdl
@@ -31,7 +31,7 @@ jobs:
       image: ghcr.io/maia-sdr/maia-sdr-devel:latest
       options: --user root
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Run cocotb Makefile

--- a/.github/workflows/maia-httpd.yml
+++ b/.github/workflows/maia-httpd.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build and test (armv7)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Format
       run: cargo fmt -- --check
     - name: Clippy
@@ -34,7 +34,7 @@ jobs:
     name: Build and test (armv7 with cross)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install cross
       run: cargo install cross
     - name: Install armv7-unknown-linux-gnueabihf Rust target
@@ -50,7 +50,7 @@ jobs:
     name: Build and test (x86_64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: cargo test
       run: cargo test --verbose
   publish:

--- a/.github/workflows/maia-json.yml
+++ b/.github/workflows/maia-json.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build and test (x86_64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Format
       run: cargo fmt -- --check
     - name: Clippy

--- a/.github/workflows/maia-wasm.yml
+++ b/.github/workflows/maia-wasm.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build and test (wasm)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Format
       run: cargo fmt -- --check
     - name: Clippy
@@ -30,7 +30,7 @@ jobs:
     name: Build and test (x86_64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: cargo test
       run: cargo test --verbose
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: katyo/publish-crates@9766ec7ed8ebbb0d34168814ecacf51833b6f97d
         with:
           registry-token: ${{ secrets.registry-token }}

--- a/.github/workflows/waterfall-example.yaml
+++ b/.github/workflows/waterfall-example.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Rust wasm
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Format
       run: cargo fmt -- --check
     - name: Clippy


### PR DESCRIPTION
The v3 action uses a deprecated NodeJS version.