### PR TITLE
maia-httpd,maia-wasm: add version information page

### DIFF
--- a/maia-httpd/Cargo.lock
+++ b/maia-httpd/Cargo.lock
@@ -519,6 +519,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +778,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "git-version",
  "http",
  "hyper",
  "libc",

--- a/maia-httpd/Cargo.toml
+++ b/maia-httpd/Cargo.toml
@@ -21,6 +21,7 @@ bytes = "1.2"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.0", features = ["derive"] }
 futures = "0.3"
+git-version = "0.3"
 http = "1.0"
 hyper = "1.1"
 libc = "0.2"

--- a/maia-httpd/src/fpga.rs
+++ b/maia-httpd/src/fpga.rs
@@ -155,13 +155,18 @@ impl IpCore {
         Ok((ip_core, interrupt_handler))
     }
 
-    fn version(&self) -> Version {
+    fn version_struct(&self) -> Version {
         let version = self.registers.version().read();
         Version {
             major: version.major().bits(),
             minor: version.minor().bits(),
             bugfix: version.bugfix().bits(),
         }
+    }
+
+    /// Gives the version of the IP core as a `String`.
+    pub fn version(&self) -> String {
+        format!("{}", self.version_struct())
     }
 
     fn check_product_id(&self) -> Result<()> {
@@ -184,7 +189,7 @@ impl IpCore {
     async fn log_open(&self) -> Result<()> {
         tracing::info!(
             "opened Maia SDR IP core version {} at physical address {:#08x}",
-            self.version(),
+            self.version_struct(),
             self.phys_addr
         );
         Ok(())

--- a/maia-httpd/src/httpd.rs
+++ b/maia-httpd/src/httpd.rs
@@ -24,6 +24,7 @@ mod iqengine;
 mod recording;
 mod spectrometer;
 mod time;
+mod version;
 mod websocket;
 mod zeros;
 
@@ -63,7 +64,7 @@ impl Server {
             recording::Recorder::new(Arc::clone(&ad9361), Arc::clone(&ip_core), waiter_recorder)
                 .await?;
         let spectrometer = spectrometer::State {
-            ip_core,
+            ip_core: Arc::clone(&ip_core),
             ad9361: Arc::clone(&ad9361),
             spectrometer_config,
         };
@@ -107,6 +108,7 @@ impl Server {
                 "/recording",
                 get(recording::get_recording).with_state(recorder.clone()),
             )
+            .route("/version", get(version::get_version).with_state(ip_core))
             .route(
                 "/waterfall",
                 get(websocket::handler).with_state(waterfall_sender),

--- a/maia-httpd/src/httpd/version.rs
+++ b/maia-httpd/src/httpd/version.rs
@@ -1,0 +1,64 @@
+use super::json_error::JsonError;
+use crate::fpga::IpCore;
+use anyhow::Result;
+use axum::{extract::State, response::Html};
+use std::sync::Arc;
+
+async fn fw_version() -> Result<String> {
+    let iio_info = tokio::fs::read_to_string("/etc/libiio.ini").await?;
+    for line in iio_info.lines() {
+        if let Some(version) = line.strip_prefix("fw_version=") {
+            return Ok(version.to_string());
+        }
+    }
+    Err(anyhow::anyhow!(
+        "/etc/libiio.ini does not contain fw_version"
+    ))
+}
+
+async fn version(ip_core: &Arc<std::sync::Mutex<IpCore>>) -> Result<String> {
+    Ok(format!(
+        r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Maia SDR</title>
+    <script type="module">
+      import init, {{ maia_wasm_git_version, maia_wasm_version }} from "./pkg/maia_wasm.js";
+
+      async function run() {{
+          await init();
+          document.getElementById('maia-wasm-git-version').innerHTML = maia_wasm_git_version();
+          document.getElementById('maia-wasm-version').innerHTML = maia_wasm_version();
+      }};
+
+      run();
+    </script>
+  </head>
+  <body>
+
+    <p>Firmware version: {}</p>
+    <p>maia-sdr git version for maia-httpd: {}</p>
+    <p>maia-httpd version: {}</p>
+    <p>maia-hdl version: {}</p>
+    <p>maia-sdr git version for maia-wasm: <span id="maia-wasm-git-version"></span></p>
+    <p>maia-wasm version: <span id="maia-wasm-version"></span></p>
+
+  </body>
+</html>
+"#,
+        fw_version().await?,
+        git_version::git_version!(fallback = "unknown"),
+        env!("CARGO_PKG_VERSION"),
+        ip_core.lock().unwrap().version(),
+    ))
+}
+
+pub async fn get_version(
+    State(ip_core): State<Arc<std::sync::Mutex<IpCore>>>,
+) -> Result<Html<String>, JsonError> {
+    version(&ip_core)
+        .await
+        .map_err(JsonError::server_error)
+        .map(Html)
+}

--- a/maia-wasm/Cargo.lock
+++ b/maia-wasm/Cargo.lock
@@ -25,6 +25,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +77,7 @@ name = "maia-wasm"
 version = "0.4.2"
 dependencies = [
  "console_error_panic_hook",
+ "git-version",
  "js-sys",
  "maia-json",
  "paste",

--- a/maia-wasm/Cargo.toml
+++ b/maia-wasm/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 console_error_panic_hook = "0.1"
+git-version = "0.3"
 js-sys = "0.3"
 maia-json = { path = "../maia-httpd/maia-json", version = "0.3.0" }
 paste = "1.0"

--- a/maia-wasm/src/lib.rs
+++ b/maia-wasm/src/lib.rs
@@ -20,6 +20,7 @@ pub mod colormap;
 pub mod pointer;
 pub mod render;
 pub mod ui;
+pub mod version;
 pub mod waterfall;
 pub mod waterfall_interaction;
 pub mod websocket;

--- a/maia-wasm/src/version.rs
+++ b/maia-wasm/src/version.rs
@@ -1,0 +1,15 @@
+//! Version information about maia-wasm.
+
+use wasm_bindgen::prelude::*;
+
+/// Gives the maia-wasm version as a `String`.
+#[wasm_bindgen]
+pub fn maia_wasm_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Gives the version of the git repository as a `String`.
+#[wasm_bindgen]
+pub fn maia_wasm_git_version() -> String {
+    git_version::git_version!(fallback = "unknown").to_string()
+}


### PR DESCRIPTION
This adds a page /version that lists version information about maia-httpd, maia-hdl and maia-wasm. maia-httpd has the information for itself filled in at compile time, and reads /etc/libiio.ini to get the firmware version, and the maia-hdl IP core registers to get the maia-hdl version. It generates a page with this information and some `<span>`'s that are filled in by JavaScript that calls maia-wasm functions that return the maia-wasm version information.