### PR TITLE
maia-hdl: improve FFT model test

### DIFF
--- a/maia-hdl/maia_hdl/fft.py
+++ b/maia-hdl/maia_hdl/fft.py
@@ -1443,6 +1443,18 @@ class FFTControl(Elaboratable):
 class FFT(Elaboratable):
     """FFT
 
+    Allowed input values:
+
+    In order to prevent internal overflows after the twiddle factor
+    multiplications, the input must have complex amplitude smaller or equal
+    than 2**(width_in-1)-1 (the complex amplitude is defined as
+    sqrt(re**2 + im**2)).
+
+    To allow the full set of possible signed width_in bit complex values,
+    the first twiddle factor multiplication should include an additional
+    bit growth of one bit, but a mode to enable this behaviour is not
+    implemented currently.
+
     Parameters
     ----------
     width_in : int


### PR DESCRIPTION
Improve the test of the FFT model against the numpy FFT by:

- Generating inputs that cover all the set of allowed values
- Testing also the case when a truncate of 0 is used in every stage
- Reducing the relative error threshold from 3e-3 to 4e-4 (the test still passes).

Additionally, clarify the allowed set of input values to prevent internal overflows in the FFT docstring.