### PR TITLE
ci: error if there are no artifcats

### DIFF
--- a/.github/workflows/plutosdr-fw.yml
+++ b/.github/workflows/plutosdr-fw.yml
@@ -36,6 +36,7 @@ jobs:
         path: |
           build/pluto.dfu
           build/pluto.frm
+        if-no-files-found: error
     # The working directory in the self-hosted runner needs be cleaned before
     # building. We use if: ${{ always() }} to clean even if the build fails.
     - name: Clean up runner working dir


### PR DESCRIPTION
I have seen cases of the docker compose build failing and the pipeline calling it good, so it looks like the Upload artifacts step still needs if-no-files-found: error.