### PR TITLE
maia-httpd: fix regression caused by axum update

### DIFF
--- a/maia-httpd/src/httpd.rs
+++ b/maia-httpd/src/httpd.rs
@@ -140,7 +140,7 @@ impl Server {
                 "/view/api/maiasdr/maiasdr/recording",
                 ServeFile::new("iqengine/index.html"),
             )
-            .route("/assets/:filename", get(iqengine::serve_assets))
+            .route("/assets/{filename}", get(iqengine::serve_assets))
             .fallback_service(ServeDir::new("."))
             .layer(TraceLayer::new_for_http());
         tracing::info!(%http_address, "starting HTTP server");


### PR DESCRIPTION
In c7d595ef06ea5c368be49a3f18b8669eaca2b4eb there was an API-breaking update of axum. This built successfully, but was not tested. There are some runtime errors caused by this update, due to a change in the syntax for extractors, as described in:

https://github.com/joelparkerhenderson/demo-rust-axum/blob/main/README.md#caution-extractors-syntax-change

This fixes the problem.