### PR TITLE
Incorporate version information as part of the settings dialog

### DIFF
--- a/maia-httpd/maia-json/src/lib.rs
+++ b/maia-httpd/maia-json/src/lib.rs
@@ -24,6 +24,8 @@ pub struct Api {
     pub spectrometer: Spectrometer,
     /// System time.
     pub time: Time,
+    /// Versions information.
+    pub versions: Versions,
 }
 
 /// AD9361 JSON schema.
@@ -571,6 +573,31 @@ impl From<Time> for PatchTime {
 pub struct DeviceGeolocation {
     /// Current device geolocation.
     pub point: Option<Geolocation>,
+}
+
+/// Versions information.
+///
+/// This JSON schema corresponds to GET requests on `/api/versions`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, Hash)]
+pub struct Versions {
+    /// Firmware version.
+    ///
+    /// This is obtained from the `fw_version` variable in `/etc/libiio.ini`.
+    pub firmware_version: String,
+    /// git version for maia-httpd.
+    ///
+    /// This is the git version of the maia-sdr repository checkout from which
+    /// maia-httpd was built.
+    pub maia_httpd_git: String,
+    /// maia-httpd version.
+    ///
+    /// This is the version of the maia-httpd crate as reported by cargo.
+    pub maia_httpd_version: String,
+    /// maia-hdl version.
+    ///
+    /// This is the version of the maia-hdl IP core as reported by the IP core
+    /// registers.
+    pub maia_hdl_version: String,
 }
 
 /// Error.

--- a/maia-httpd/src/httpd.rs
+++ b/maia-httpd/src/httpd.rs
@@ -102,6 +102,7 @@ impl Server {
                     .put(recording::put_recording_metadata)
                     .patch(recording::patch_recording_metadata),
             )
+            .route("/api/versions", get(version::get_versions))
             .route("/recording", get(recording::get_recording))
             .route("/version", get(version::get_version))
             // IQEngine viewer for IQ recording

--- a/maia-httpd/src/httpd/api.rs
+++ b/maia-httpd/src/httpd/api.rs
@@ -6,6 +6,7 @@ use super::{
     recording::{recorder_json, recording_metadata_json},
     spectrometer::spectrometer_json,
     time::time_json,
+    version,
 };
 use crate::app::AppState;
 use anyhow::Result;
@@ -22,6 +23,7 @@ async fn api_json(state: &AppState) -> Result<maia_json::Api> {
     let recording_metadata = recording_metadata_json(state).await;
     let geolocation = device_geolocation(state);
     let time = time_json()?;
+    let versions = version::versions(state.ip_core()).await?;
     Ok(maia_json::Api {
         ad9361,
         ddc,
@@ -30,6 +32,7 @@ async fn api_json(state: &AppState) -> Result<maia_json::Api> {
         recorder,
         recording_metadata,
         time,
+        versions,
     })
 }
 

--- a/maia-wasm/assets/index.html
+++ b/maia-wasm/assets/index.html
@@ -119,6 +119,9 @@
         </div>
         <div id="other_panel" class="hidden" role="tabpanel" aria-labelledby="other_tab">
           <a href="ca.crt">CA certificate</a>
+          <p>firmware <span id="firmware_version"></span></p>
+          <p>maia-httpd <span id="maia_httpd_version"></span></p>
+          <p>maia-hdl <span id="maia_hdl_version"></span></p>
           <p>maia-wasm <span id="maia_wasm_version"></span></p>
         </div>
     </dialog>

--- a/maia-wasm/src/ui.rs
+++ b/maia-wasm/src/ui.rs
@@ -119,6 +119,9 @@ ui_elements! {
     geolocation_update: HtmlButtonElement => Rc<HtmlButtonElement>,
     geolocation_watch: HtmlInputElement => CheckboxInput,
     geolocation_clear: HtmlButtonElement => Rc<HtmlButtonElement>,
+    firmware_version: HtmlSpanElement => Rc<HtmlSpanElement>,
+    maia_httpd_version: HtmlSpanElement => Rc<HtmlSpanElement>,
+    maia_hdl_version: HtmlSpanElement => Rc<HtmlSpanElement>,
     maia_wasm_version: HtmlSpanElement => Rc<HtmlSpanElement>,
 }
 
@@ -317,6 +320,7 @@ impl Ui {
         self.update_recording_metadata_inactive_elements(&json.recording_metadata)?;
         self.update_recorder_inactive_elements(&json.recorder)?;
         self.update_geolocation_elements(&json.geolocation)?;
+        self.update_versions_elements(&json.versions);
 
         // This potentially takes some time to complete, since it might have to
         // do a fetch call to PATCH the server time. We do this last.
@@ -1016,6 +1020,24 @@ impl Ui {
             request::ignore_request_failed(self.patch_time(&patch).await)?;
         }
         Ok(())
+    }
+}
+
+// Versions methods
+impl Ui {
+    fn update_versions_elements(&self, json: &maia_json::Versions) {
+        self.elements
+            .firmware_version
+            .set_text_content(Some(&json.firmware_version));
+        self.elements
+            .maia_httpd_version
+            .set_text_content(Some(&format!(
+                "v{} git {}",
+                json.maia_httpd_version, json.maia_httpd_git,
+            )));
+        self.elements
+            .maia_hdl_version
+            .set_text_content(Some(&json.maia_hdl_version));
     }
 }
 


### PR DESCRIPTION
This adds the versions information to the maia-httpd REST API and displays them in the "Other" in settings tab in the maia-wasm web UI.