### PR TITLE
maia-httpd: allow CORS requests from any origin

### DIFF
--- a/maia-httpd/Cargo.toml
+++ b/maia-httpd/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { version = "1", features = ["fs", "rt", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-tar = "0.3"
 tokio-util = { version = "0.7", features = ["io"] }
-tower-http = { version = "0.6", features = ["fs", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/maia-httpd/src/httpd.rs
+++ b/maia-httpd/src/httpd.rs
@@ -14,6 +14,7 @@ use bytes::Bytes;
 use std::{net::SocketAddr, path::Path};
 use tokio::sync::broadcast;
 use tower_http::{
+    cors::CorsLayer,
     services::{ServeDir, ServeFile},
     trace::TraceLayer,
 };
@@ -143,6 +144,7 @@ impl Server {
             )
             .route("/assets/{filename}", get(iqengine::serve_assets))
             .fallback_service(ServeDir::new("."))
+            .layer(CorsLayer::permissive()) // allow requests from any origin
             .layer(TraceLayer::new_for_http());
         tracing::info!(%http_address, "starting HTTP server");
         let http_server = axum_server::bind(http_address);


### PR DESCRIPTION
Use tower_http's CorsLayer::permissive() to allow CORS requests from any origin. This allows using maia-httpd from webapps running on other servers.