### PR TITLE
ci: install build before building maia-hdl package

### DIFF
--- a/.github/workflows/maia-hdl.yml
+++ b/.github/workflows/maia-hdl.yml
@@ -46,6 +46,8 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags/maia-hdl-')
     needs: [python-formatting, python-tests, cocotb-tests]
     steps:
+      - name: Install build with pip
+        run: pip install build
       - name: Build Python package
         run: python -mbuild
       - name: Publish to PyPI


### PR DESCRIPTION
Apparently build is no longer installed by default in the ubuntu-latest Github runner, so this workflow is failing.