### PR TITLE
maia-kmod: fix kernel 6.4+ and 6.11+ API compatibility

### DIFF
--- a/maia-kmod/maia-sdr.c
+++ b/maia-kmod/maia-sdr.c
@@ -18,6 +18,7 @@
 #include <linux/of_device.h>
 #include <linux/of_reserved_mem.h>
 #include <linux/platform_device.h>
+#include <linux/version.h>
 
 #define DRIVER_NAME "maia-sdr"
 
@@ -295,8 +296,8 @@ static int maia_sdr_probe_recording(struct platform_device *pdev)
 
 	cdev_init(&drvdata->cdev, &recording_fops);
 	drvdata->cdev.owner = THIS_MODULE;
-	minor = ida_simple_get(&maia_sdr_device_ida, 0, MAIA_SDR_MINOR_MAX,
-			       GFP_KERNEL);
+	minor = ida_alloc_range(&maia_sdr_device_ida, 0,
+				MAIA_SDR_MINOR_MAX - 1, GFP_KERNEL);
 	if (minor < 0) {
 		ret = minor;
 		goto probe_recording_error;
@@ -350,7 +351,7 @@ probe_recording_error:
 		cdev_del(&drvdata->cdev);
 	}
 	if (minor >= 0) {
-		ida_simple_remove(&maia_sdr_device_ida, minor);
+		ida_free(&maia_sdr_device_ida, minor);
 	}
 	if (!IS_ERR_OR_NULL(drvdata)) {
 		devm_kfree(&pdev->dev, drvdata);
@@ -406,8 +407,8 @@ static int maia_sdr_probe_rxbuffer(struct platform_device *pdev)
 
 	cdev_init(&drvdata->cdev, &rxbuffer_fops);
 	drvdata->cdev.owner = THIS_MODULE;
-	minor = ida_simple_get(&maia_sdr_device_ida, 0, MAIA_SDR_MINOR_MAX,
-			       GFP_KERNEL);
+	minor = ida_alloc_range(&maia_sdr_device_ida, 0,
+				MAIA_SDR_MINOR_MAX - 1, GFP_KERNEL);
 	if (minor < 0) {
 		ret = minor;
 		goto probe_rxbuffer_error;
@@ -461,7 +462,7 @@ probe_rxbuffer_error:
 		cdev_del(&drvdata->cdev);
 	}
 	if (minor >= 0) {
-		ida_simple_remove(&maia_sdr_device_ida, minor);
+		ida_free(&maia_sdr_device_ida, minor);
 	}
 	if (!IS_ERR_OR_NULL(drvdata)) {
 		devm_kfree(&pdev->dev, drvdata);
@@ -502,7 +503,7 @@ static int maia_sdr_probe(struct platform_device *pdev)
 	}
 }
 
-static int maia_sdr_remove_recording(struct platform_device *pdev)
+static void maia_sdr_remove_recording(struct platform_device *pdev)
 {
 	struct maia_sdr_recording_drvdata *drvdata = platform_get_drvdata(pdev);
 
@@ -510,12 +511,11 @@ static int maia_sdr_remove_recording(struct platform_device *pdev)
 	device_remove_file(&pdev->dev, &dev_attr_recording_size);
 	device_destroy(maia_sdr_class, drvdata->device_number);
 	cdev_del(&drvdata->cdev);
-	ida_simple_remove(&maia_sdr_device_ida, MINOR(drvdata->device_number));
+	ida_free(&maia_sdr_device_ida, MINOR(drvdata->device_number));
 	devm_kfree(&pdev->dev, drvdata);
-	return 0;
 }
 
-static int maia_sdr_remove_rxbuffer(struct platform_device *pdev)
+static void maia_sdr_remove_rxbuffer(struct platform_device *pdev)
 {
 	struct maia_sdr_rxbuffer_drvdata *drvdata = platform_get_drvdata(pdev);
 
@@ -523,30 +523,46 @@ static int maia_sdr_remove_rxbuffer(struct platform_device *pdev)
 	device_remove_file(&pdev->dev, &dev_attr_buffer_size);
 	device_destroy(maia_sdr_class, drvdata->device_number);
 	cdev_del(&drvdata->cdev);
-	ida_simple_remove(&maia_sdr_device_ida, MINOR(drvdata->device_number));
+	ida_free(&maia_sdr_device_ida, MINOR(drvdata->device_number));
 	devm_kfree(&pdev->dev, drvdata);
-	return 0;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void maia_sdr_remove(struct platform_device *pdev)
+#else
 static int maia_sdr_remove(struct platform_device *pdev)
+#endif
 {
 	const struct maia_sdr_device_data *devdata;
 	const struct of_device_id *of_id =
 		of_match_device(of_match_ptr(maia_sdr_of_match), &pdev->dev);
 	if (!of_id) {
 		pr_alert("no of_match_device found");
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+		return;
+#else
 		return -EINVAL;
+#endif
 	}
 	devdata = of_id->data;
 	switch (devdata->type) {
 	case MAIA_SDR_RECORDING:
-		return maia_sdr_remove_recording(pdev);
+		maia_sdr_remove_recording(pdev);
+		break;
 	case MAIA_SDR_RXBUFFER:
-		return maia_sdr_remove_rxbuffer(pdev);
+		maia_sdr_remove_rxbuffer(pdev);
+		break;
 	default:
 		pr_alert("unsupported device type");
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+		return;
+#else
 		return -EINVAL;
+#endif
 	}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
+	return 0;
+#endif
 }
 
 MODULE_DEVICE_TABLE(of, maia_sdr_of_match);
@@ -586,7 +602,11 @@ static int __init maia_sdr_init(void)
 		goto error;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	maia_sdr_class = class_create(DRIVER_NAME);
+#else
 	maia_sdr_class = class_create(THIS_MODULE, DRIVER_NAME);
+#endif
 	if (IS_ERR_OR_NULL(maia_sdr_class)) {
 		ret = maia_sdr_class ? PTR_ERR(maia_sdr_class) : -ENOMEM;
 		pr_alert("%s: class_create failed with %d\n", DRIVER_NAME, ret);


### PR DESCRIPTION
## Summary

Update deprecated/removed kernel APIs in `maia-kmod/maia-sdr.c` for compatibility with Linux 6.4+ and 6.11+:

1. **`class_create(THIS_MODULE, name)` -> `class_create(name)`** — `THIS_MODULE` argument removed in 6.4 ([1aaba11da9aa](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1aaba11da9aa))
2. **`ida_simple_get()` -> `ida_alloc_range()`** — deprecated in 6.4 ([cb77285caa20](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=cb77285caa20)). Note: `ida_alloc_range()` max is inclusive (unlike `ida_simple_get()` which was exclusive), so `MAIA_SDR_MINOR_MAX - 1` is used.
3. **`ida_simple_remove()` -> `ida_free()`** — corresponding rename
4. **`platform_driver .remove` return type `int` -> `void`** — changed in 6.11 ([0edb555a65d1](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0edb555a65d1))

## Testing

Hardware-tested on a Zynq-7020 / AD9361 board (FISH Ball PlutoSDR) running Linux 6.12.0 from the ADI kernel tree (`analogdevicesinc/linux` branch `adi-6.12.0`). The maia-sdr kernel module loads successfully and both the recording and rxbuffer character devices function correctly. Maia-SDR waterfall and SweepFFT verified working via the web UI.

## Context

These fixes originate from the [tezuka_fw](https://github.com/F5OEO/tezuka_fw) Buildroot-based firmware project, which bumped its ADI Linux kernel from 6.1 to 6.12. The fixes were initially carried as a local Buildroot patch against v0.10.0 and have been validated across multiple build/boot cycles.

Without these changes, `maia-kmod` cannot compile against Linux >= 6.4 (build errors from removed `class_create` signature and deprecated IDA functions) or Linux >= 6.11 (incompatible `.remove` callback signature).
